### PR TITLE
fix: 高德电子地图使用https地址

### DIFF
--- a/src/imagery/amap/AmapImageryProvider.js
+++ b/src/imagery/amap/AmapImageryProvider.js
@@ -9,7 +9,7 @@ const IMG_URL =
   'https://webst{s}.is.autonavi.com/appmaptile?style=6&x={x}&y={y}&z={z}'
 
 const ELEC_URL =
-  'http://webrd{s}.is.autonavi.com/appmaptile?lang=zh_cn&size=1&scale=1&style=8&x={x}&y={y}&z={z}'
+  'https://webrd{s}.is.autonavi.com/appmaptile?lang=zh_cn&size=1&scale=1&style=8&x={x}&y={y}&z={z}'
 
 class AmapImageryProvider extends Cesium.UrlTemplateImageryProvider {
   constructor(options = {}) {


### PR DESCRIPTION
在页面启用https的情况下无法加载高德地图电子地图切片数据,切换高德电子地图使用https地址

Signed-off-by: kerbores <kerbores@gmail.com>
